### PR TITLE
Properly handle coverage.py leftovers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 
 .tox/
 .coverage
+htmlcov
 
 # vi
 .*.swp

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ release: clean
 
 clean:
 	@echo "Cleaning files"
+	@if [ -d  htmlcov ] ; then rm -r htmlcov ; fi
 	@if [ -d .tox ] ; then rm -r .tox ; fi
 	@if [ -d .pytest_cache ] ; then rm -r .pytest_cache ; fi
 	@find . -iname __pycache__ -exec rm -r {} +


### PR DESCRIPTION
We should clean up leftovers and make sure they don't appear in git.