### PR TITLE
Add upgrade-charm symlink

### DIFF
--- a/hooks/upgrade-charm
+++ b/hooks/upgrade-charm
@@ -1,0 +1,1 @@
+../src/charm.py


### PR DESCRIPTION
In order for the operator charm to run an upgrade from a non-operator
charm, we need the upgrade-charm symlink provided so that the remaining
hooks get created.