### PR TITLE
Fixing charmcraft.yaml > 3.4 for multiple platforms

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,6 +70,7 @@ jobs:
         bases:
           - ubuntu@20.04
           - ubuntu@22.04
+          - ubuntu@24.04
     name: Integration tests (LXD) | ${{ matrix.bases }}
     runs-on: ubuntu-latest
     needs:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -25,36 +25,27 @@ provides:
     scope: container
 subordinate: true
 
-bases:
-  - build-on:
-      - name: "ubuntu"
-        channel: "22.04"
-        architectures: [amd64]
-    run-on:
-      - name: "ubuntu"
-        channel: "22.04"
-        architectures: [amd64]
-  - build-on:
-      - name: "ubuntu"
-        channel: "22.04"
-        architectures: [arm64]
-    run-on:
-      - name: "ubuntu"
-        channel: "22.04"
-        architectures: [arm64]
-  - build-on:
-      - name: "ubuntu"
-        channel: "20.04"
-        architectures: [amd64]
-    run-on:
-      - name: "ubuntu"
-        channel: "20.04"
-        architectures: [amd64]
-  - build-on:
-      - name: "ubuntu"
-        channel: "20.04"
-        architectures: [arm64]
-    run-on:
-      - name: "ubuntu"
-        channel: "20.04"
-        architectures: [arm64]
+platforms:
+  ubuntu-24.04-amd64:
+    build-on: [ubuntu@24.04:amd64]
+    build-for: [ubuntu@24.04:amd64]
+  ubuntu-24.04-arm64:
+    build-on: [ubuntu@24.04:arm64]
+    build-for: [ubuntu@24.04:arm64]
+  ubuntu-22.04-amd64:
+    build-on: [ubuntu@22.04:amd64]
+    build-for: [ubuntu@22.04:amd64]
+  ubuntu-22.04-arm64:
+    build-on: [ubuntu@22.04:arm64]
+    build-for: [ubuntu@22.04:arm64]
+  ubuntu-20.04-amd64:
+    build-on: [ubuntu@20.04:amd64]
+    build-for: [ubuntu@20.04:amd64]
+  ubuntu-20.04-arm64:
+    build-on: [ubuntu@20.04:arm64]
+    build-for: [ubuntu@20.04:arm64]
+
+parts:
+  charm:
+    plugin: charm
+    source: .


### PR DESCRIPTION
it was ok yesterday but new charmcraft 3.4 requires new format
[1] https://canonical-charmcraft.readthedocs-hosted.com/en/stable/howto/build-guides/select-platforms/#select-multiple-os-releases